### PR TITLE
instruction updates to improve usability part 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ curl https://eynvwoxb7l.execute-api.us-east-1.amazonaws.com/helix-services/domai
 It will tell you that it needs a `domain` parameter, so we try again
 
 ```bash
-curl -F domain=example.com https://eynvwoxb7l.execute-api.us-east-1.amazonaws.com/helix-services/domainkey-provider/v1/
+curl -d domain=example.com https://eynvwoxb7l.execute-api.us-east-1.amazonaws.com/helix-services/domainkey-provider/v1/
 ```
 
 This will return instruction on setting completing the callenge. The response
@@ -40,7 +40,7 @@ Once the record is set, you can call the service again to verify that the challe
 has been completed and start issuing domain keys.
 
 ```bash
-curl -F domain=example.com -F domainkey=f4a5cb7f-adac-450c-919f-a12b13cec116 https://eynvwoxb7l.execute-api.us-east-1.amazonaws.com/helix-services/domainkey-provider/v1/
+curl -d domain=example.com -d domainkey=f4a5cb7f-adac-450c-919f-a12b13cec116 https://eynvwoxb7l.execute-api.us-east-1.amazonaws.com/helix-services/domainkey-provider/v1/
 ```
 
 If the domain key has been verified and activated, you will see a response status of

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Once the record is set, you can call the service again to verify that the challe
 has been completed and start issuing domain keys.
 
 ```bash
-curl -d domain=example.com -d domainkey=f4a5cb7f-adac-450c-919f-a12b13cec116 https://eynvwoxb7l.execute-api.us-east-1.amazonaws.com/helix-services/domainkey-provider/v1/
+curl -d "domain=example.com&domainkey=f4a5cb7f-adac-450c-919f-a12b13cec116" https://eynvwoxb7l.execute-api.us-east-1.amazonaws.com/helix-services/domainkey-provider/v1/
 ```
 
 If the domain key has been verified and activated, you will see a response status of

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ curl https://eynvwoxb7l.execute-api.us-east-1.amazonaws.com/helix-services/domai
 It will tell you that it needs a `domain` parameter, so we try again
 
 ```bash
-curl -d domain=example.com https://eynvwoxb7l.execute-api.us-east-1.amazonaws.com/helix-services/domainkey-provider/v1/
+curl -X POST -d domain=example.com https://eynvwoxb7l.execute-api.us-east-1.amazonaws.com/helix-services/domainkey-provider/v1/
 ```
 
 This will return instruction on setting completing the callenge. The response
@@ -40,7 +40,7 @@ Once the record is set, you can call the service again to verify that the challe
 has been completed and start issuing domain keys.
 
 ```bash
-curl -d "domain=example.com&domainkey=f4a5cb7f-adac-450c-919f-a12b13cec116" https://eynvwoxb7l.execute-api.us-east-1.amazonaws.com/helix-services/domainkey-provider/v1/
+curl -X POST -d "domain=example.com&domainkey=f4a5cb7f-adac-450c-919f-a12b13cec116" https://eynvwoxb7l.execute-api.us-east-1.amazonaws.com/helix-services/domainkey-provider/v1/
 ```
 
 If the domain key has been verified and activated, you will see a response status of

--- a/src/index.js
+++ b/src/index.js
@@ -59,7 +59,7 @@ async function run(request, context) {
 the record is added, you can verify that it is set up correctly by making a POST request to this URL including
 the domain and domainkey parameters. For example:
 
-curl -X POST -F "domain=${domain}" -F "domainkey=${newkey}" ${currentURL}
+curl -X POST -d "domain=${domain}&domainkey=${newkey}" ${currentURL}
 `;
     return new Response(instructions, {
       status: 404,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -54,7 +54,13 @@ describe('Index Tests', () => {
   });
 
   it('index returns 404 if text record is not set', async () => {
-    const result = await main(new Request('https://localhost/?domain=example.com&domainkey=foo'), {
+    const result = await main(new Request('https://localhost/', {
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      method: 'POST',
+      body: 'domain=example.com&domainkey=foo',
+    }), {
       env: {
         HELIX_RUN_QUERY_DOMAIN_KEY: 'foo',
       },
@@ -64,7 +70,13 @@ describe('Index Tests', () => {
   });
 
   it('index returns 403 if text record is set but wrong', async () => {
-    const result = await main(new Request('https://localhost/?domain=johansminecraft.club&domainkey=bar'), {
+    const result = await main(new Request('https://localhost/', {
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      method: 'POST',
+      body: 'domain=johansminecraft.club&domainkey=bar',
+    }), {
       env: {
         HELIX_RUN_QUERY_DOMAIN_KEY: 'foo',
       },
@@ -74,7 +86,13 @@ describe('Index Tests', () => {
   });
 
   it('index returns 503 if rotating the domainkey failed for backend reasons', async () => {
-    const result = await main(new Request('https://localhost/?domain=johansminecraft.club&domainkey=foo'), {
+    const result = await main(new Request('https://localhost/', {
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      method: 'POST',
+      body: 'domain=johansminecraft.club&domainkey=foo',
+    }), {
       env: {
         HELIX_RUN_QUERY_DOMAIN_KEY: 'baz', // this key is wrong on purpose, so that the update won't go through
       },
@@ -84,7 +102,13 @@ describe('Index Tests', () => {
   }).timeout(50000);
 
   it('index returns 201 if rotating the domainkey worked as expected', async () => {
-    const result = await main(new Request('https://localhost/?domain=johansminecraft.club&domainkey=foo'), {
+    const result = await main(new Request('https://localhost/', {
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      method: 'POST',
+      body: 'domain=johansminecraft.club&domainkey=foo',
+    }), {
       env: {
         HELIX_RUN_QUERY_DOMAIN_KEY: process.env.TEST_DOMAINKEY, // this one is real,
         // but only for one domain

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -37,7 +37,7 @@ describe('Index Tests', () => {
   it('index generates a domain key if not specified', async () => {
     const result = await main(new Request('https://localhost/', {
       method: 'POST',
-      body: 'domain=example.com'
+      body: 'domain=example.com',
     }), {
       env: {
         HELIX_RUN_QUERY_DOMAIN_KEY: 'foo',

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -36,6 +36,9 @@ describe('Index Tests', () => {
 
   it('index generates a domain key if not specified', async () => {
     const result = await main(new Request('https://localhost/', {
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
       method: 'POST',
       body: 'domain=example.com',
     }), {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -35,7 +35,10 @@ describe('Index Tests', () => {
   });
 
   it('index generates a domain key if not specified', async () => {
-    const result = await main(new Request('https://localhost/?domain=example.com'), {
+    const result = await main(new Request('https://localhost/', {
+      method: 'POST',
+      body: 'domain=example.com'
+    }), {
       env: {
         HELIX_RUN_QUERY_DOMAIN_KEY: 'foo',
       },


### PR DESCRIPTION
This is a carryover from closed PR #23 with updated instructions and updated tests which use the POST method.

These comments from @tripodsan still apply, repeating here so they don't get lost:

- move to tier2
- add authorizer
- only access via admin.hlx.page/domain

@coatpont please attempt again with TXT record for your domain using the new syntax in this README.  Note that the instructions in the prompt from the URL ending in /v1 are outdated.  If you want to see the new instructions in the prompt in addition to the instructions from the README, please substitute /v1 with /ci241 in your curl command.  Ping me with any questions.
